### PR TITLE
Do not output cron errors

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -159,7 +159,7 @@ then
 	# SET THE CRON
 	#=================================================
 
-	echo "0 1 * * * root \"$final_path/send_process/send_backup.sh\" > /dev/null" > /etc/cron.d/$app
+	echo "0 1 * * * root \"$final_path/send_process/send_backup.sh\" > /dev/null 2>&1" > /etc/cron.d/$app
 
 	#=================================================
 	# CREATE DIRECTORIES


### PR DESCRIPTION
Hello,

I have setup the fallback server but I receive every night an email with the cron output of the fallback script.
I fixed all errors I had with the applications backup scripts, but still I receive the email.
I understand that some commands and scripts do not output standard information to stdout, so I guess there is no alternative than disabling the output of the fallback backup cron task.

Here is an exemple of cron email report I got before, and that I do not get anymore:

```bash
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
It's hightly recommended to make your backup when the service is stopped. Please stop gitea service and with this command before to run the backup 'systemctl stop gitea.service'
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
sh: BASH_XTRACEFD : 7 : valeur non valable pour un descripteur de fichier de trace
Debian GNU/Linux 10
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
sending incremental file list
.d..t...... backup/
<f..t...... backup/app_list.cpt
<f..t...... backup/config.conf.cpt
[...]

Number of files: 15 (reg: 14, dir: 1)
Number of created files: 0
Number of deleted files: 0
Number of regular files transferred: 7
Total file size: 540.46M bytes
Total transferred file size: 217.29M bytes
Literal data: 217.29M bytes
Matched data: 14 bytes
File list size: 0
File list generation time: 0.001 seconds
File list transfer time: 0.000 seconds
Total bytes sent: 217.34M
Total bytes received: 162.42K

sent 217.34M bytes  received 162.42K bytes  7.63M bytes/sec
total size is 540.46M  speedup is 2.48
```

So if you're OK to not receive the cron report email, please accept the merge request. If you think it's not the correct solution, I let you implement what you think is better.